### PR TITLE
chore(lint): extend ESLint to electron and build scripts, fix existing errors

### DIFF
--- a/avatar/eslint.config.js
+++ b/avatar/eslint.config.js
@@ -7,7 +7,8 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   globalIgnores(['dist']),
   {
-    files: ['**/*.{js,jsx}'],
+    // Renderer — browser globals, React rules.
+    files: ['src/**/*.{js,jsx}'],
     extends: [
       js.configs.recommended,
       reactHooks.configs['recommended-latest'],
@@ -24,6 +25,41 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+    },
+  },
+  {
+    // Electron main / preload — CommonJS, Node globals. Previously matched no
+    // config block at all, so main.cjs and the VRoid Hub modules were parsed
+    // but had zero rules applied.
+    files: ['electron/**/*.cjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: globals.node,
+    },
+    rules: {
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+    },
+  },
+  {
+    // Build tooling — Node globals. The test suites need nothing extra: they
+    // require('node:test') rather than relying on injected globals.
+    files: ['*.config.js', 'scripts/**/*.{js,mjs}'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.node,
+    },
+  },
+  {
+    files: ['scripts/**/*.cjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: globals.node,
     },
   },
 ])

--- a/avatar/package.json
+++ b/avatar/package.json
@@ -17,7 +17,7 @@
     "icons": "node scripts/make-icons.mjs",
     "test": "node --test electron/*.test.cjs",
     "dist:win": "npm run icons && cross-env AVATAR_SHIP=1 vite build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --win nsis",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/avatar/scripts/make-icons.mjs
+++ b/avatar/scripts/make-icons.mjs
@@ -70,11 +70,7 @@ console.log('wrote build/icon.ico', ico.length, 'bytes');
 
 // NSIS assets: copy public PNGs into build/ and emit the BMPs electron-builder expects.
 // Sizes are already NSIS-correct (top 150×57, side 164×314); keep them unversioned.
-const installerAssets = [
-  { name: 'installer_top', width: 150, height: 57 },
-  { name: 'installer_side', width: 164, height: 314 },
-];
-
+// The authoritative list is the $assets array inside the PowerShell block below.
 const installerPs = `
 Add-Type -AssemblyName System.Drawing
 $public = '${path.join(root, 'public').replace(/'/g, "''")}'

--- a/avatar/src/components/AvatarStage.jsx
+++ b/avatar/src/components/AvatarStage.jsx
@@ -747,7 +747,6 @@ export function AvatarStage() {
             <VoicePanel
               audioSourceId={audioSourceId}
               setAudioSourceId={setAudioSourceId}
-              audioFile={audioFile}
               setAudioFile={setAudioFile}
               windowSourceId={windowSourceId}
               setWindowSourceId={setWindowSourceId}

--- a/avatar/src/components/avatar/VrmAvatar.jsx
+++ b/avatar/src/components/avatar/VrmAvatar.jsx
@@ -39,6 +39,10 @@ export function VrmAvatar({
       return undefined;
     }
 
+    // Captured once so the cleanup detaches from the same group this run
+    // attached to, even if the ref has been repointed by the time it fires.
+    const container = group.current;
+
     loader.load(
       modelPath,
       (gltf) => {
@@ -58,7 +62,7 @@ export function VrmAvatar({
         VRMUtils.rotateVRM0(vrmData);
 
         loaded = vrmData;
-        group.current?.add(vrmData.scene);
+        container?.add(vrmData.scene);
         setVrm(vrmData);
         onLoaded?.();
       },
@@ -72,9 +76,9 @@ export function VrmAvatar({
     return () => {
       disposed = true;
       setVrm(null);
-      if (group.current) {
-        while (group.current.children.length > 0) {
-          group.current.remove(group.current.children[0]);
+      if (container) {
+        while (container.children.length > 0) {
+          container.remove(container.children[0]);
         }
       }
       // Detaching a scene leaves its geometries, materials and textures on the

--- a/avatar/src/components/panels/VoicePanel.jsx
+++ b/avatar/src/components/panels/VoicePanel.jsx
@@ -6,7 +6,6 @@ import { PanelSelect } from '../ui/PanelPrimitives';
 export function VoicePanel({
   audioSourceId,
   setAudioSourceId,
-  audioFile,
   setAudioFile,
   windowSourceId,
   setWindowSourceId,


### PR DESCRIPTION
## Why

`npm run lint` only ever checked `src/` plus the two root config files. The flat config had a single block matching `**/*.{js,jsx}`, so every `electron/*.cjs` file — `main.cjs`, `preload.cjs`, and the VRoid Hub modules — was parsed with zero rules applied, and `scripts/*.mjs` was never matched at all.

Linting was also red on `main`, which meant it could not be used as a merge gate. This PR is a prerequisite for the CI workflow requested in #4: without it, that workflow fails on its first run.

## Config changes

- Scope the renderer block to `src/` (browser globals + React rules).
- Add an `electron/**/*.cjs` block: commonjs, Node globals, recommended. The test suites need no extra globals — they `require('node:test')`.
- Add blocks for `*.config.js` and `scripts/**` with Node globals.
- Move `--max-warnings=0` into the `lint` script so local and CI agree.

## Fixes surfaced by the wider net

- **`VoicePanel.jsx`** — destructured an unused `audioFile`; the file input is uncontrolled and only needs the setter. Dropped the prop at the call site too.
- **`VrmAvatar.jsx`** — read `group.current` in effect cleanup. Capture the group once and use it for both attach and detach, so a model swap detaches from the group it attached to. This one is an actual bug, not just a lint complaint.
- **`scripts/make-icons.mjs`** — dropped a dead `installerAssets` array that duplicated the sizes already inlined in the PowerShell block: a trap if someone edited one and not the other.

## Verification

Lint coverage goes from 40 to 55 files. `npm run lint`, `npm run build`, and the 26 `electron/*.test.cjs` tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
