### PR TITLE
docs: add CI status badge to the README badge row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       ELECTRON_SKIP_BINARY_DOWNLOAD: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           # Vite 7 needs ^20.19.0 || >=22.12.0.
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, test, build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: avatar
+    env:
+      # Nothing here launches Electron: the unit-tested modules deliberately
+      # avoid require('electron'), so the ~100 MB binary is dead weight.
+      ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # Vite 7 needs ^20.19.0 || >=22.12.0.
+          node-version: 22
+          cache: npm
+          cache-dependency-path: avatar/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-ffb38a?style=flat-square" alt="License MIT" /></a>
   <a href="https://vrm.dev/ja/"><img src="https://img.shields.io/badge/BOOTH-VRM-f87171?style=flat-square" alt="BOOTH VRM" /></a>
   <a href="https://hub.vroid.com/en/"><img src="https://img.shields.io/badge/VRoid-Hub-f0d78c?style=flat-square" alt="VRoid Hub" /></a>
+  <a href="https://github.com/ARPAHLS/avatar/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/ARPAHLS/avatar/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
 </div>
 
 <p align="center">

--- a/avatar/eslint.config.js
+++ b/avatar/eslint.config.js
@@ -7,7 +7,8 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   globalIgnores(['dist']),
   {
-    files: ['**/*.{js,jsx}'],
+    // Renderer — browser globals, React rules.
+    files: ['src/**/*.{js,jsx}'],
     extends: [
       js.configs.recommended,
       reactHooks.configs['recommended-latest'],
@@ -24,6 +25,41 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+    },
+  },
+  {
+    // Electron main / preload — CommonJS, Node globals. Previously matched no
+    // config block at all, so main.cjs and the VRoid Hub modules were parsed
+    // but had zero rules applied.
+    files: ['electron/**/*.cjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: globals.node,
+    },
+    rules: {
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+    },
+  },
+  {
+    // Build tooling — Node globals. The test suites need nothing extra: they
+    // require('node:test') rather than relying on injected globals.
+    files: ['*.config.js', 'scripts/**/*.{js,mjs}'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.node,
+    },
+  },
+  {
+    files: ['scripts/**/*.cjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: globals.node,
     },
   },
 ])

--- a/avatar/package.json
+++ b/avatar/package.json
@@ -17,7 +17,7 @@
     "icons": "node scripts/make-icons.mjs",
     "test": "node --test electron/*.test.cjs",
     "dist:win": "npm run icons && cross-env AVATAR_SHIP=1 vite build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --win nsis",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/avatar/scripts/make-icons.mjs
+++ b/avatar/scripts/make-icons.mjs
@@ -70,11 +70,7 @@ console.log('wrote build/icon.ico', ico.length, 'bytes');
 
 // NSIS assets: copy public PNGs into build/ and emit the BMPs electron-builder expects.
 // Sizes are already NSIS-correct (top 150×57, side 164×314); keep them unversioned.
-const installerAssets = [
-  { name: 'installer_top', width: 150, height: 57 },
-  { name: 'installer_side', width: 164, height: 314 },
-];
-
+// The authoritative list is the $assets array inside the PowerShell block below.
 const installerPs = `
 Add-Type -AssemblyName System.Drawing
 $public = '${path.join(root, 'public').replace(/'/g, "''")}'

--- a/avatar/src/components/AvatarStage.jsx
+++ b/avatar/src/components/AvatarStage.jsx
@@ -747,7 +747,6 @@ export function AvatarStage() {
             <VoicePanel
               audioSourceId={audioSourceId}
               setAudioSourceId={setAudioSourceId}
-              audioFile={audioFile}
               setAudioFile={setAudioFile}
               windowSourceId={windowSourceId}
               setWindowSourceId={setWindowSourceId}

--- a/avatar/src/components/avatar/VrmAvatar.jsx
+++ b/avatar/src/components/avatar/VrmAvatar.jsx
@@ -39,6 +39,10 @@ export function VrmAvatar({
       return undefined;
     }
 
+    // Captured once so the cleanup detaches from the same group this run
+    // attached to, even if the ref has been repointed by the time it fires.
+    const container = group.current;
+
     loader.load(
       modelPath,
       (gltf) => {
@@ -58,7 +62,7 @@ export function VrmAvatar({
         VRMUtils.rotateVRM0(vrmData);
 
         loaded = vrmData;
-        group.current?.add(vrmData.scene);
+        container?.add(vrmData.scene);
         setVrm(vrmData);
         onLoaded?.();
       },
@@ -72,9 +76,9 @@ export function VrmAvatar({
     return () => {
       disposed = true;
       setVrm(null);
-      if (group.current) {
-        while (group.current.children.length > 0) {
-          group.current.remove(group.current.children[0]);
+      if (container) {
+        while (container.children.length > 0) {
+          container.remove(container.children[0]);
         }
       }
       // Detaching a scene leaves its geometries, materials and textures on the

--- a/avatar/src/components/panels/VoicePanel.jsx
+++ b/avatar/src/components/panels/VoicePanel.jsx
@@ -6,7 +6,6 @@ import { PanelSelect } from '../ui/PanelPrimitives';
 export function VoicePanel({
   audioSourceId,
   setAudioSourceId,
-  audioFile,
   setAudioFile,
   windowSourceId,
   setWindowSourceId,


### PR DESCRIPTION
## Merge after #35

This is the optional follow-up noted in #4 ("Badge on README once stable"). It should not be merged until #35 has landed and the CI workflow has run on `main` at least once.

Merging it early is not harmful, but the badge will render as a grey `CI: no status` until `ci.yml` exists on `ARPAHLS/avatar` — the shields endpoint has no workflow to read. Confirmed against the live endpoint:

- `.../ARPAHLS/avatar/ci.yml?branch=main` → `CI: no status` (today)
- same query against the fork, where `ci.yml` already exists → `CI: passing`

Full chain: #34 → #35 → this. GitHub shows the earlier commits here until those merge; this PR reduces to the single README line once they do.

## What

One line added to the existing badge row in `README.md`:

```html
<a href="https://github.com/ARPAHLS/avatar/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/ARPAHLS/avatar/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
```

## Why shields.io instead of GitHub's native badge

GitHub's own `actions/workflows/ci.yml/badge.svg` is dark grey with square corners and a fixed layout, which sits badly next to the four `flat-square` pastel badges already in that row. The shields.io dynamic endpoint accepts `style=flat-square` so it matches.

The trade-off: unlike its neighbours — which use the static `/badge/` endpoint with hardcoded pastel hex values like `b8d4f0` — this one uses the dynamic status endpoint, so shields picks the colour from the actual result. It will be standard green or red, not a pastel. There is no way to have both live status and a custom palette. Happy to switch to the native badge instead if you would rather not mix the two styles.

## Note on `?branch=main`

Required. Without it the badge reflects the most recent run on *any* ref, including open PRs, so a contributor's failing branch would show the project as red. Pinning to `main` is what makes it a statement about the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
