### PR TITLE
fix(scripts): tear down vite when the desktop dev window closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Capture the Three.js group once in `VrmAvatar` so effect cleanup detaches from the same container the model was attached to (avoids orphan scenes on avatar swap). (#34)
 - Drop unused `audioFile` prop from `VoicePanel` (file input is uncontrolled). (#34)
+- `npm run dev:desktop` now passes `concurrently -k` so closing the Electron window (or killing Vite) tears down both processes and frees port 5173. (#37, #38)
 
 ## [0.5.0] — 2026-08-06
 

--- a/avatar/package.json
+++ b/avatar/package.json
@@ -10,7 +10,7 @@
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "vite",
-    "dev:desktop": "concurrently -n vite,electron -c cyan,magenta \"vite --port 5173 --strictPort\" \"wait-on http://localhost:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
+    "dev:desktop": "concurrently -n vite,electron -c cyan,magenta -k \"vite --port 5173 --strictPort\" \"wait-on http://localhost:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
     "thumbs": "concurrently -n vite,electron -c cyan,magenta -k --success first \"vite --port 5174 --strictPort\" \"wait-on http://localhost:5174 && cross-env AVATAR_GEN_THUMBS=1 VITE_DEV_SERVER_URL=http://localhost:5174 electron .\"",
     "desktop": "npm run build && cross-env NODE_ENV=production electron .",
     "build": "vite build",


### PR DESCRIPTION
Closes #37.

`dev:desktop` ran `concurrently` without `-k`, so vite and Electron were
independent children. Closing the AVATAR window ended only Electron and left
vite listening on 5173, which then blocked the next `npm run dev:desktop` with
`Port 5173 is already in use` — against a server the developer had no reason to
think was still running.

The neighbouring `thumbs` script already passes `-k`, so this was an oversight
rather than a deliberate difference. One flag, matching that precedent.

### Verification

Both teardown directions, confirmed with `netstat` showing 5173 released and no
leftover processes:

- killed vite -> Electron exited with it
- closed the AVATAR window -> vite exited with it

### Scope

Developer-facing only. `dist:win` and the packaged app do not use this script,
and no runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)