### PR TITLE
fix(environments): revoke library blob urls only after their replacement lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Capture the Three.js group once in `VrmAvatar` so effect cleanup detaches from the same container the model was attached to (avoids orphan scenes on avatar swap). (#34)
 - Drop unused `audioFile` prop from `VoicePanel` (file input is uncontrolled). (#34)
 - `npm run dev:desktop` now passes `concurrently -k` so closing the Electron window (or killing Vite) tears down both processes and frees port 5173. (#37, #38)
+- Custom environment library blob URLs are revoked only after the replacement list is in state, so the stage/picker never briefly reference dead `blob:` URLs while a Directories folder switch loads. (#39, #40)
 
 ## [0.5.0] — 2026-08-06
 

--- a/avatar/src/components/AvatarStage.jsx
+++ b/avatar/src/components/AvatarStage.jsx
@@ -362,7 +362,12 @@ export function AvatarStage() {
     let cancelled = false;
 
     async function refreshEnvLibrary() {
-      revokeEnvironmentBlobUrls(libraryEnvironmentsRef.current);
+      // Revoking before the await left the stage and the picker pointing at
+      // urls that no longer resolve for as long as the replacement took to
+      // load. Already-decoded images survive revocation, so nothing changed on
+      // screen — but a remount in that window loaded nothing. Hold the old list
+      // and drop it only once its replacement is in state (#39).
+      const previous = libraryEnvironmentsRef.current;
       const useLibrary =
         desktopMode &&
         directories.environments.mode === 'custom' &&
@@ -370,7 +375,10 @@ export function AvatarStage() {
 
       if (!useLibrary) {
         setLibraryCustomEnvironments([]);
-        if (!cancelled) setLibraryEnvironments([]);
+        if (!cancelled) {
+          setLibraryEnvironments([]);
+          revokeEnvironmentBlobUrls(previous);
+        }
         return;
       }
 
@@ -378,11 +386,13 @@ export function AvatarStage() {
         directories.environments.path,
       );
       if (cancelled) {
+        // A newer run captured the same `previous` and owns retiring it.
         revokeEnvironmentBlobUrls(next);
         return;
       }
       setLibraryEnvironments(next);
       setLibraryCustomEnvironments(next);
+      revokeEnvironmentBlobUrls(previous);
       if (error) {
         setDirectoriesNotice(error);
         setDirectories((prev) => ({

--- a/avatar/src/components/AvatarStage.jsx
+++ b/avatar/src/components/AvatarStage.jsx
@@ -401,6 +401,7 @@ export function AvatarStage() {
         }));
         setLibraryEnvironments([]);
         setLibraryCustomEnvironments([]);
+        revokeEnvironmentBlobUrls(next);
         setSelectedBg((prev) =>
           prev.type === 'env' && String(prev.id).startsWith('lib-env-')
             ? { type: 'color', value: defaultColor }
@@ -418,6 +419,7 @@ export function AvatarStage() {
         }));
         setLibraryEnvironments([]);
         setLibraryCustomEnvironments([]);
+        revokeEnvironmentBlobUrls(next);
         setSelectedBg((prev) =>
           prev.type === 'env' && String(prev.id).startsWith('lib-env-')
             ? { type: 'color', value: defaultColor }


### PR DESCRIPTION
Closes #39.

`refreshEnvLibrary` revoked the previous folder's blob URLs on its first line and
then awaited the replacement, leaving the stage and the picker pointing at URLs
that no longer resolved. Already-decoded images survive revocation so nothing
looked wrong on screen, but a fresh load of those URLs failed — which is what
remounting the accordion does.

The previous list is now held in a local and dropped once the replacement is in
state. The cancelled path deliberately does not revoke it: a newer run captured
the same list and owns retiring it, so revoking there would just move the
early-revoke window up a level.

### Verification

Probe hooks `URL.revokeObjectURL` and tests every blob URL the DOM and
`--holo-image` reference for liveness. Identical folder switch and protocol
across both runs; this change is the only variable:

| | before | after |
|---|---|---|
| revoke burst | 2 | 2 |
| referenced | 1 | 1 |
| **dead** | **1** | **0** |
| fresh `<img>` for a dead url | FAILED | n/a |
| verdict | `CONFIRMED — the ui referenced revoked urls` | `clean — referenced urls stayed alive throughout` |

The reference also survives the whole load now instead of disappearing once
React falls back to a bundled environment, so the old background stays visible
until the new folder is ready.

### Scope

Only the environments library path. Does not touch #22 — that investigation ruled
out the main thread and is waiting on reporter info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)