### PR TITLE
fix(voice): clearer capture status and privacy copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Voice panel and docs spell out capture status and privacy.** Gear → **Voice** shows plain-language status (`Starting capture…`, `Capturing (local)`, …) instead of raw tokens, keeps a local-only privacy note next to the source picker, and turns permission failures into actionable copy (with a desktop button into system privacy settings on Windows/macOS). [Audio sources](docs/voice/audio-sources.md) expands permissions troubleshooting and a short “what stays local” section; the README privacy line matches. (#12)
+
 ### Fixed
 
 ## [0.7.0] — 2026-08-16

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Beyond the bundled samples, you can bring your own characters and backdrops: **S
 
 ## Privacy
 
-Runs locally. Audio uses Web APIs / Electron loopback; nothing is uploaded. See [audio sources](docs/voice/audio-sources.md) for capture options.
+Runs locally. Audio uses Web APIs / Electron loopback so the mouth can follow what you hear; **AVATAR only measures levels on this device for lip sync — nothing is uploaded.** Capture may ask for microphone or screen/audio permission; that stays in the local process. Details: [audio sources — privacy](docs/voice/audio-sources.md#privacy-what-stays-local).
 
 ---
 

--- a/avatar/electron/main.cjs
+++ b/avatar/electron/main.cjs
@@ -246,6 +246,12 @@ function assertTrustedLibrarySender(event) {
   }
 }
 
+function assertTrustedDesktopSender(event) {
+  if (!mainWindow || mainWindow.isDestroyed() || event.senderFrame !== mainWindow.webContents.mainFrame) {
+    throw new Error('Rejected desktop IPC call from an untrusted sender.');
+  }
+}
+
 function getLogoPath() {
   return path.join(__dirname, '../public/AVATAR_LOGO_150.png');
 }
@@ -515,6 +521,22 @@ ipcMain.handle('desktop:sample-luma', async () => {
   } catch {
     return null;
   }
+});
+
+// Allowlisted OS privacy panes only — never a free-form URL from the renderer.
+ipcMain.handle('shell:open-privacy-settings', (event) => {
+  assertTrustedDesktopSender(event);
+  if (process.platform === 'win32') {
+    void shell.openExternal('ms-settings:privacy-microphone');
+    return true;
+  }
+  if (process.platform === 'darwin') {
+    void shell.openExternal(
+      'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone',
+    );
+    return true;
+  }
+  return false;
 });
 
 ipcMain.handle('window:snap', (_event, corner) => {

--- a/avatar/electron/preload.cjs
+++ b/avatar/electron/preload.cjs
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('voxDesktop', {
   setWindowScale: (factor) => ipcRenderer.invoke('window:set-scale', factor),
   getDesktopSources: (types) => ipcRenderer.invoke('desktop:get-sources', types),
   sampleDesktopLuma: () => ipcRenderer.invoke('desktop:sample-luma'),
+  openPrivacySettings: () => ipcRenderer.invoke('shell:open-privacy-settings'),
   onPositionSettled: (callback) => {
     const listener = () => callback();
     ipcRenderer.on('window:position-settled', listener);

--- a/avatar/src/components/panels/VoicePanel.jsx
+++ b/avatar/src/components/panels/VoicePanel.jsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
 import { getAudioSourceOptions } from '../../config/audioSources';
+import {
+  AUDIO_PRIVACY_NOTE,
+  labelAudioCaptureStatus,
+} from '../../lib/audioCaptureCopy';
 import { getDesktopApi } from '../../lib/desktopMode';
 import { PanelSelect } from '../ui/PanelPrimitives';
 
@@ -16,6 +20,11 @@ export function VoicePanel({
   const [windowSources, setWindowSources] = useState([]);
   const audioSourceOptions = getAudioSourceOptions();
   const desktopApi = getDesktopApi();
+  const statusLabel = labelAudioCaptureStatus(audioStatus);
+  const showPermissionHint =
+    audioStatus === 'error' &&
+    typeof audioError === 'string' &&
+    /permission denied/i.test(audioError);
 
   useEffect(() => {
     if (audioSourceId !== 'window' || !desktopApi?.getDesktopSources) return;
@@ -39,6 +48,7 @@ export function VoicePanel({
           ? 'Device output captures all PC audio automatically. Pick a window when you only want one app (Chrome, Discord, etc.).'
           : 'Choose an audio source to drive real-time lip sync. Tab capture works best for AI assistants or media in the browser.'}
       </p>
+      <p className="panel-note panel-note--compact">{AUDIO_PRIVACY_NOTE}</p>
 
       <label className="field-label" htmlFor="audio-source-select">
         Audio source
@@ -79,8 +89,22 @@ export function VoicePanel({
       )}
 
       <div className="voice-status-row">
-        <span className={`voice-status voice-status--${audioStatus}`}>{audioStatus}</span>
+        <span
+          className={`voice-status voice-status--${audioStatus}`}
+          title={typeof audioStatus === 'string' ? audioStatus : undefined}
+        >
+          {statusLabel}
+        </span>
         {audioError && <span className="voice-error">{audioError}</span>}
+        {showPermissionHint && desktopApi?.openPrivacySettings && (
+          <button
+            type="button"
+            className="panel-button"
+            onClick={() => void desktopApi.openPrivacySettings()}
+          >
+            Open system privacy settings
+          </button>
+        )}
       </div>
 
       <button type="button" className="panel-button" onClick={onRestartAudio}>

--- a/avatar/src/config/audioSources.js
+++ b/avatar/src/config/audioSources.js
@@ -41,7 +41,7 @@ const desktopOptions = [
     id: 'system',
     label: 'Device output (auto)',
     description:
-      'Captures whatever audio your PC is playing — music, Chrome, assistants, games. Uses Windows/macOS loopback in the desktop app.',
+      'Captures whatever audio your PC is playing — music, Chrome, assistants, games. Uses OS loopback in the desktop app; levels stay on this device.',
     requiresPermission: true,
   },
   {

--- a/avatar/src/hooks/useAudioSource.js
+++ b/avatar/src/hooks/useAudioSource.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { formatAudioCaptureError } from '../lib/audioCaptureCopy';
 import { captureDesktopSource, captureSystemLoopback } from '../lib/electronAudio';
 import { useAudioAnalyser } from './useAudioAnalyser';
 
@@ -136,9 +137,7 @@ export function useAudioSource(sourceId, audioFile = null, options = {}) {
 
       setStatus('active');
     } catch (cause) {
-      const message =
-        cause instanceof Error ? cause.message : 'Could not start the selected audio source.';
-      setError(message);
+      setError(formatAudioCaptureError(cause));
       setStatus('error');
       await cleanup();
     }

--- a/avatar/src/lib/audioCaptureCopy.js
+++ b/avatar/src/lib/audioCaptureCopy.js
@@ -1,0 +1,65 @@
+/**
+ * User-facing copy for Voice capture status and errors.
+ * Kept free of React so `node --test` can load it.
+ */
+
+/** @typedef {'idle' | 'starting' | 'active' | 'error' | 'awaiting-window' | 'awaiting-file' | string} AudioCaptureStatus */
+
+/**
+ * @param {AudioCaptureStatus} status
+ * @returns {string}
+ */
+export function labelAudioCaptureStatus(status) {
+  switch (status) {
+    case 'idle':
+      return 'Idle';
+    case 'starting':
+      return 'Starting capture…';
+    case 'active':
+      return 'Capturing (local)';
+    case 'error':
+      return 'Couldn’t start capture';
+    case 'awaiting-window':
+      return 'Pick a window or screen above';
+    case 'awaiting-file':
+      return 'Pick an audio file above';
+    default:
+      return typeof status === 'string' && status.trim() !== '' ? status : 'Unknown';
+  }
+}
+
+/**
+ * Turn a raw capture failure into short, actionable copy.
+ * @param {unknown} cause
+ * @returns {string}
+ */
+export function formatAudioCaptureError(cause) {
+  const name = cause && typeof cause === 'object' && 'name' in cause ? String(cause.name) : '';
+  const raw =
+    cause instanceof Error
+      ? cause.message
+      : typeof cause === 'string'
+        ? cause
+        : 'Could not start the selected audio source.';
+
+  const folded = `${name} ${raw}`.toLowerCase();
+
+  if (
+    name === 'NotAllowedError' ||
+    folded.includes('permission') ||
+    folded.includes('not allowed') ||
+    folded.includes('denied')
+  ) {
+    return 'Permission denied. Allow microphone or screen/audio capture for AVATAR, then use Restart audio capture. On Windows: Settings → Privacy & security → Microphone (and Screen and voice recording if listed).';
+  }
+
+  if (folded.includes('could not start') || folded.includes('failed to get')) {
+    return `${raw} Try Restart audio capture, or pick another source.`;
+  }
+
+  return raw;
+}
+
+/** One-line privacy promise shown in the Voice panel. */
+export const AUDIO_PRIVACY_NOTE =
+  'AVATAR measures audio levels on this device for lip sync. Nothing is uploaded or sent to a server.';

--- a/avatar/src/lib/audioCaptureCopy.test.mjs
+++ b/avatar/src/lib/audioCaptureCopy.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  AUDIO_PRIVACY_NOTE,
+  formatAudioCaptureError,
+  labelAudioCaptureStatus,
+} from './audioCaptureCopy.js';
+
+describe('labelAudioCaptureStatus', () => {
+  it('maps known statuses to readable labels', () => {
+    assert.equal(labelAudioCaptureStatus('idle'), 'Idle');
+    assert.equal(labelAudioCaptureStatus('starting'), 'Starting capture…');
+    assert.equal(labelAudioCaptureStatus('active'), 'Capturing (local)');
+    assert.equal(labelAudioCaptureStatus('error'), 'Couldn’t start capture');
+    assert.equal(labelAudioCaptureStatus('awaiting-window'), 'Pick a window or screen above');
+    assert.equal(labelAudioCaptureStatus('awaiting-file'), 'Pick an audio file above');
+  });
+});
+
+describe('formatAudioCaptureError', () => {
+  it('turns NotAllowedError into an actionable permission message', () => {
+    const error = new Error('Permission denied');
+    error.name = 'NotAllowedError';
+    const text = formatAudioCaptureError(error);
+    assert.match(text, /Permission denied/i);
+    assert.match(text, /Restart audio capture/);
+    assert.match(text, /Windows/i);
+  });
+
+  it('passes through other messages', () => {
+    assert.equal(formatAudioCaptureError(new Error('No audio track available.')), 'No audio track available.');
+  });
+});
+
+describe('AUDIO_PRIVACY_NOTE', () => {
+  it('states local-only analysis', () => {
+    assert.match(AUDIO_PRIVACY_NOTE, /this device/i);
+    assert.match(AUDIO_PRIVACY_NOTE, /Nothing is uploaded/i);
+  });
+});

--- a/avatar/src/styles/app.css
+++ b/avatar/src/styles/app.css
@@ -1307,7 +1307,7 @@
 }
 
 .voice-status {
-  text-transform: capitalize;
+  font-weight: 500;
 }
 
 .voice-status--active {

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -20,7 +20,7 @@ Near-term product work on the desktop companion.
 
 - [ ] Reactive glass-bar live dot (amplitude + capture status) (#42)
 - [ ] Improve lip-sync beyond amplitude cycling (#9)
-- [ ] Clearer capture-permission and privacy copy (#12)
+- [x] Clearer capture-permission and privacy copy (#12)
 
 ### Appearance & performance
 
@@ -78,6 +78,8 @@ Longer arc — plug-and-play adapters, not hard-coded models. See also [Your AI 
 ---
 
 ## Landed on main since v0.7.0
+
+- [x] Clearer Voice capture-permission and privacy copy (#12)
 
 ## v0.7.0 — Shipped
 

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -71,7 +71,7 @@ Scale is remembered in `config.yaml`.
 
 ### Live lip-sync dot
 
-A **green pulsing dot** appears when lip sync is actively capturing (`Audio source` not Off, status `active`). Hover title: *Lip sync active*.
+A **green pulsing dot** appears when lip sync is actively capturing (`Audio source` not Off, status **Capturing (local)**). Hover title: *Lip sync active*.
 
 ### Gear menu
 
@@ -190,9 +190,10 @@ Gear → **Voice**.
 
 ### Tips
 
-- Status line shows `idle` / `starting` / `active` / `error` / …
-- Use **Restart audio capture** if OS permissions or devices change.
-- Mouth shapes are **amplitude-based** (not phoneme ASR). See [Lip sync](voice/lip-sync.md) and [Audio sources](voice/audio-sources.md).
+- Status shows a short plain-language line (for example **Capturing (local)** or **Pick a window…**), not raw codes.
+- A privacy note in the panel states that lip sync analyses levels **locally** — nothing is uploaded.
+- Use **Restart audio capture** if OS permissions or devices change; on permission denial, desktop builds can open system privacy settings.
+- Mouth shapes are **amplitude-based** (not phoneme ASR). See [Lip sync](voice/lip-sync.md) and [Audio sources](voice/audio-sources.md) (permissions + privacy).
 
 <p align="center">
   <img src="screenshots/50-voice-panel.png" alt="Voice panel" height="200" />

--- a/docs/voice/audio-sources.md
+++ b/docs/voice/audio-sources.md
@@ -15,7 +15,7 @@ This is the full reference for every lip-sync input. Mouth shapes themselves are
 | Option | id | Description |
 | :--- | :--- | :--- |
 | **Device output (auto)** | `system` | **Default.** Captures what your speakers play (loopback). Best for music, videos, local LLMs talking through the OS mixer. |
-| **Pick app window** | `window` | Choose a specific window/screen from the **Window or screen** list, then wait until status is `active`. |
+| **Pick app window** | `window` | Choose a specific window/screen from the **Window or screen** list, then wait until status reads **Capturing (local)**. |
 | **Microphone** | `microphone` | Your default input device. |
 | **Audio file** | `file` | Pick a local audio file; it plays into the analyser. |
 | **Off** | `none` | Lip sync disabled; green live dot hidden. |
@@ -28,9 +28,15 @@ This is the full reference for every lip-sync input. Mouth shapes themselves are
 
 ### Permissions / troubleshooting
 
-- First capture may prompt for screen/audio permission depending on the OS.  
-- If status sticks on `error` or `starting`, click **Restart audio capture**.  
-- `awaiting-window` / `awaiting-file` means finish picking a target.
+- First capture may prompt for **microphone** or **screen/audio** permission depending on the OS and source. That is expected for Device output, Pick app window, Microphone, and browser Tab capture.
+- Status in Gear → **Voice** is written in plain language (`Starting capture…`, `Capturing (local)`, `Pick a window…`, …). Older builds showed raw tokens such as `starting` / `error`.
+- If capture is denied, the panel explains that **permission was refused**, suggests **Restart audio capture**, and on desktop can open **system privacy settings** (Windows: Settings → Privacy & security → Microphone; also check Screen and voice recording if your OS lists it).
+- If status sticks on an error after you allow access, click **Restart audio capture**, or switch source Off and back.
+- `Pick a window…` / `Pick an audio file…` means finish choosing a target — not a failure.
+
+### Privacy (what stays local)
+
+AVATAR uses capture only to **measure audio levels on this device** for lip sync (amplitude → mouth shapes). Streams are not recorded to disk as part of Voice, and **nothing is uploaded** to ARPA or any third-party avatar service. Device output / window capture may use the OS screen-audio APIs; that still stays in the local process. See also the short privacy line in the [README](../../README.md#privacy).
 
 ---
 
@@ -49,7 +55,7 @@ System-wide **device output** loopback is an Electron feature — use the [Windo
 
 ## Live indicator
 
-When the source is not Off and status is **`active`**, a **green pulsing dot** appears on the glass bar (title: *Lip sync active*).
+When the source is not Off and status is **Capturing (local)** (internal `active`), a **green pulsing dot** appears on the glass bar (title: *Lip sync active*).
 
 <p align="center">
   <img src="../screenshots/11-bar-live-dot.png" alt="Live lip-sync dot" height="120" />

--- a/docs/voice/lip-sync.md
+++ b/docs/voice/lip-sync.md
@@ -22,7 +22,7 @@ Pick the input first: [Audio sources](audio-sources.md). Everyday steps: [Using 
 ## Live UI
 
 Glass bar **green pulsing dot** = capture active and lip sync enabled.  
-Voice drawer shows status text (`idle`, `starting`, `active`, `error`, …) and **Restart audio capture**.
+Voice drawer shows a **plain-language status** (for example **Capturing (local)** or **Starting capture…**), a short **local-only privacy** note, and **Restart audio capture**. Permission failures include actionable copy (desktop can open system privacy settings). Details: [Audio sources → Privacy](audio-sources.md#privacy-what-stays-local).
 
 <p align="center">
   <img src="../screenshots/11-bar-live-dot.png" alt="Live dot" height="100" />


### PR DESCRIPTION
Plain-language Voice status, local-only privacy note, actionable permission errors with a desktop link into OS privacy settings, and matching docs/README. Refs #12.