### PR TITLE
feat(glass-bar): reactive live dot from capture status and amplitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Reactive glass-bar live dot** — when an audio source is selected, the 8px indicator shows waiting (amber), live quiet→loud (mint→green from analyser level), or error (coral), instead of a binary always-green pulse. Amplitude updates via a level ref on the dot node so the bar does not take an extra React state path for loudness. (#42)
+
 ### Changed
 
 - Settings section **Motion** is now **Animation hotkeys** (same `motionDeck` settings). The Add-animation picker and the deck list keep the mouse wheel until they hit the end of their own scroll, then the Settings drawer scrolls again.

--- a/avatar/src/components/AvatarStage.jsx
+++ b/avatar/src/components/AvatarStage.jsx
@@ -41,6 +41,7 @@ import {
 import { loadUserSettings, resetUserSettings, saveUserSettings } from '../lib/userSettingsStore';
 import { revokeThumbnailUrls } from '../lib/thumbnails';
 import { revokeEnvironmentThumbnailUrls } from '../lib/environmentThumbnails';
+import { resolveLiveDotMode } from '../lib/liveDot';
 import { VrmAvatar } from './avatar/VrmAvatar';
 import { AvatarStageShell } from './avatar/AvatarStageShell';
 import { CameraController } from './ui/CameraController';
@@ -117,13 +118,18 @@ export function AvatarStage() {
 
   const desktopApi = getDesktopApi();
 
-  const { level, speaking, status: audioStatus, error: audioError, restart } = useAudioSource(
+  const { level, levelRef, speaking, status: audioStatus, error: audioError, restart } = useAudioSource(
     audioSourceId,
     audioFile,
     { windowSourceId },
   );
 
   const lipSyncEnabled = audioSourceId !== 'none' && audioStatus === 'active';
+  const liveDotMode = resolveLiveDotMode({
+    audioSourceId,
+    audioStatus,
+    audioError,
+  });
 
   const applySettings = useCallback((settings) => {
     setSelectedAvatarId(settings.avatarId);
@@ -934,7 +940,8 @@ export function AvatarStage() {
           overlayMode={overlayMode}
           onOverlayModeToggle={handleOverlayModeToggle}
           onCloseWindow={handleCloseWindow}
-          lipSyncLive={lipSyncEnabled}
+          liveDotMode={liveDotMode}
+          liveDotLevelRef={levelRef}
         >
           <Canvas
             camera={{ position: camera.position, fov: camera.fov }}

--- a/avatar/src/components/avatar/AvatarStageShell.jsx
+++ b/avatar/src/components/avatar/AvatarStageShell.jsx
@@ -11,6 +11,7 @@ import {
 import { getDesktopApi, isDesktopMode } from '../../lib/desktopMode';
 import { BarCommandMenu } from '../ui/BarCommandMenu';
 import { WindowScaleMenu } from '../ui/WindowScaleMenu';
+import { LiveDot } from './LiveDot';
 
 export function AvatarStageShell({
   environmentSelection,
@@ -30,7 +31,8 @@ export function AvatarStageShell({
   overlayMode,
   onOverlayModeToggle,
   onCloseWindow,
-  lipSyncLive,
+  liveDotMode,
+  liveDotLevelRef,
   children,
 }) {
   const { barHeight, canvasOverflowTop, canvasOverflowSide } = STAGE;
@@ -143,9 +145,7 @@ export function AvatarStageShell({
               onSelectScale={onWindowScaleChange}
               menuRef={scaleMenuRef}
             />
-            {lipSyncLive && (
-              <span className="avatar-glass-bar__live-dot" title="Lip sync active" aria-label="Lip sync active" />
-            )}
+            <LiveDot mode={liveDotMode} levelRef={liveDotLevelRef} />
             <button
               type="button"
               className={`avatar-glass-bar__gear ${commandMenuOpen ? 'avatar-glass-bar__gear--open' : ''}`}

--- a/avatar/src/components/avatar/LiveDot.jsx
+++ b/avatar/src/components/avatar/LiveDot.jsx
@@ -1,0 +1,56 @@
+import { memo, useLayoutEffect, useRef } from 'react';
+import { liveDotLabel, normalizeLiveLevel } from '../../lib/liveDot';
+
+/**
+ * Glass-bar lip-sync indicator (#42).
+ *
+ * Discrete mode comes from React (waiting / live / error). While `live`,
+ * amplitude is written straight onto the span via rAF + a shared level ref so
+ * the bar does not need a dedicated setState path for loudness.
+ *
+ * @param {Object} props
+ * @param {import('../../lib/liveDot').LiveDotMode | null} props.mode
+ * @param {{ current: number } | null} [props.levelRef]
+ */
+export const LiveDot = memo(function LiveDot({ mode, levelRef = null }) {
+  const nodeRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const node = nodeRef.current;
+    if (!node) return undefined;
+
+    if (mode !== 'live' || !levelRef) {
+      node.style.setProperty('--live-level', '0');
+      return undefined;
+    }
+
+    let raf = 0;
+    let lastLabel = '';
+    const tick = () => {
+      const next = normalizeLiveLevel(levelRef.current);
+      node.style.setProperty('--live-level', next.toFixed(3));
+      const label = liveDotLabel('live', next);
+      if (label !== lastLabel) {
+        lastLabel = label;
+        node.title = label;
+        node.setAttribute('aria-label', label);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [mode, levelRef]);
+
+  if (!mode) return null;
+
+  const label = liveDotLabel(mode, 0);
+
+  return (
+    <span
+      ref={nodeRef}
+      className={`avatar-glass-bar__live-dot avatar-glass-bar__live-dot--${mode}`}
+      title={label}
+      aria-label={label}
+    />
+  );
+});

--- a/avatar/src/hooks/useAudioAnalyser.js
+++ b/avatar/src/hooks/useAudioAnalyser.js
@@ -43,6 +43,8 @@ export function useAudioAnalyser(enabled) {
   const analyserRef = useRef(null);
   const bufferRef = useRef(null);
   const lastSpeechRef = useRef(0);
+  // Always current RMS for chrome that must not depend on React (live dot).
+  const levelRef = useRef(0);
 
   const attach = useCallback((sourceNode, audioContext, options = {}) => {
     if (!sourceNode || !audioContext) return;
@@ -54,6 +56,7 @@ export function useAudioAnalyser(enabled) {
   const detach = useCallback(() => {
     analyserRef.current = null;
     bufferRef.current = null;
+    levelRef.current = 0;
     setLevel(0);
     setSpeaking(false);
   }, []);
@@ -70,6 +73,7 @@ export function useAudioAnalyser(enabled) {
       const buffer = bufferRef.current;
       if (analyser && buffer) {
         const nextLevel = measureLevel(analyser, buffer);
+        levelRef.current = nextLevel;
         setLevel(nextLevel);
         const now = performance.now();
         if (nextLevel > SPEAKING_THRESHOLD) {
@@ -88,5 +92,5 @@ export function useAudioAnalyser(enabled) {
     };
   }, [detach, enabled]);
 
-  return { attach, detach, level, speaking };
+  return { attach, detach, level, levelRef, speaking };
 }

--- a/avatar/src/hooks/useAudioSource.js
+++ b/avatar/src/hooks/useAudioSource.js
@@ -18,7 +18,7 @@ export function useAudioSource(sourceId, audioFile = null, options = {}) {
   const audioElementRef = useRef(null);
   const enabled = sourceId !== 'none';
 
-  const { attach, detach, level, speaking } = useAudioAnalyser(enabled);
+  const { attach, detach, level, levelRef, speaking } = useAudioAnalyser(enabled);
 
   const cleanup = useCallback(async () => {
     detach();
@@ -152,6 +152,7 @@ export function useAudioSource(sourceId, audioFile = null, options = {}) {
 
   return {
     level,
+    levelRef,
     speaking,
     status,
     error,

--- a/avatar/src/lib/liveDot.js
+++ b/avatar/src/lib/liveDot.js
@@ -1,0 +1,47 @@
+/**
+ * Discrete glass-bar live-dot mode from capture state (#42).
+ * Amplitude (quiet ↔ loud green) is applied continuously while mode is `live`.
+ *
+ * @typedef {'waiting' | 'live' | 'error'} LiveDotMode
+ */
+
+/**
+ * @param {Object} args
+ * @param {string} args.audioSourceId
+ * @param {string} args.audioStatus
+ * @param {unknown} [args.audioError]
+ * @returns {LiveDotMode | null} null = hidden
+ */
+export function resolveLiveDotMode({ audioSourceId, audioStatus, audioError }) {
+  if (!audioSourceId || audioSourceId === 'none') return null;
+  if (audioStatus === 'error' || audioError) return 'error';
+  if (audioStatus === 'active') return 'live';
+  // idle / starting (and any other pre-active status)
+  return 'waiting';
+}
+
+/** Map analyser RMS into 0…1 for CSS `--live-level`. */
+export function normalizeLiveLevel(level) {
+  if (typeof level !== 'number' || !(level > 0)) return 0;
+  // Same ballpark as speaking threshold (~0.012); speech often sits under ~0.1.
+  return Math.min(1, level / 0.08);
+}
+
+export const LIVE_DOT_LABELS = {
+  waiting: 'Lip sync waiting for audio',
+  liveQuiet: 'Lip sync listening',
+  liveActive: 'Lip sync active',
+  error: 'Lip sync error — open Voice',
+};
+
+/**
+ * @param {LiveDotMode} mode
+ * @param {number} level
+ */
+export function liveDotLabel(mode, level) {
+  if (mode === 'waiting') return LIVE_DOT_LABELS.waiting;
+  if (mode === 'error') return LIVE_DOT_LABELS.error;
+  return normalizeLiveLevel(level) < 0.15
+    ? LIVE_DOT_LABELS.liveQuiet
+    : LIVE_DOT_LABELS.liveActive;
+}

--- a/avatar/src/lib/liveDot.test.mjs
+++ b/avatar/src/lib/liveDot.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  liveDotLabel,
+  normalizeLiveLevel,
+  resolveLiveDotMode,
+} from './liveDot.js';
+
+describe('resolveLiveDotMode', () => {
+  it('hides the dot when the source is Off', () => {
+    assert.equal(
+      resolveLiveDotMode({ audioSourceId: 'none', audioStatus: 'idle' }),
+      null,
+    );
+  });
+
+  it('shows waiting while a source is selected but not yet capturing', () => {
+    assert.equal(
+      resolveLiveDotMode({ audioSourceId: 'system', audioStatus: 'starting' }),
+      'waiting',
+    );
+    assert.equal(
+      resolveLiveDotMode({ audioSourceId: 'microphone', audioStatus: 'idle' }),
+      'waiting',
+    );
+  });
+
+  it('shows live once capture is active', () => {
+    assert.equal(
+      resolveLiveDotMode({ audioSourceId: 'system', audioStatus: 'active' }),
+      'live',
+    );
+  });
+
+  it('shows error from status or error payload', () => {
+    assert.equal(
+      resolveLiveDotMode({ audioSourceId: 'system', audioStatus: 'error' }),
+      'error',
+    );
+    assert.equal(
+      resolveLiveDotMode({
+        audioSourceId: 'system',
+        audioStatus: 'idle',
+        audioError: 'denied',
+      }),
+      'error',
+    );
+  });
+});
+
+describe('normalizeLiveLevel', () => {
+  it('clamps and scales RMS into 0…1', () => {
+    assert.equal(normalizeLiveLevel(0), 0);
+    assert.equal(normalizeLiveLevel(-1), 0);
+    assert.ok(normalizeLiveLevel(0.02) > 0);
+    assert.equal(normalizeLiveLevel(0.08), 1);
+    assert.equal(normalizeLiveLevel(1), 1);
+  });
+});
+
+describe('liveDotLabel', () => {
+  it('picks quiet vs active copy from level while live', () => {
+    assert.match(liveDotLabel('live', 0), /listening/);
+    assert.match(liveDotLabel('live', 0.05), /active/);
+    assert.match(liveDotLabel('waiting', 0), /waiting/);
+    assert.match(liveDotLabel('error', 0), /error/);
+  });
+});

--- a/avatar/src/styles/app.css
+++ b/avatar/src/styles/app.css
@@ -295,28 +295,63 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
+  flex-shrink: 0;
+  /* Amplitude 0…1 while --live; ignored for waiting / error. */
+  --live-level: 0;
   background: #84cc16;
   box-shadow:
-    0 0 6px rgba(132, 204, 22, 0.85),
-    0 0 12px rgba(163, 230, 53, 0.55);
-  animation: avatar-live-dot-pulse 1.8s ease-in-out infinite;
+    0 0 6px rgba(132, 204, 22, 0.55),
+    0 0 12px rgba(163, 230, 53, 0.35);
 }
 
-@keyframes avatar-live-dot-pulse {
+/* Soft amber — source on, capture not ready yet. */
+.avatar-glass-bar__live-dot--waiting {
+  background: #e4c46a;
+  box-shadow:
+    0 0 5px rgba(228, 196, 106, 0.55),
+    0 0 10px rgba(228, 196, 106, 0.28);
+  animation: avatar-live-dot-breathe 2.4s ease-in-out infinite;
+}
+
+/* Capture healthy: pastel mint at silence → brighter lime as level rises. */
+.avatar-glass-bar__live-dot--live {
+  background: color-mix(in srgb, #9bb8a8, #84cc16 calc(var(--live-level) * 100%));
+  box-shadow:
+    0 0 calc(4px + (var(--live-level) * 6px)) color-mix(in srgb, #9bb8a8, #84cc16 calc(var(--live-level) * 100%)),
+    0 0 calc(8px + (var(--live-level) * 10px)) color-mix(in srgb, transparent, #a3e635 calc(var(--live-level) * 55%));
+  transform: scale(calc(1 + (var(--live-level) * 0.22)));
+  opacity: calc(0.72 + (var(--live-level) * 0.28));
+  animation: none;
+}
+
+/* Soft coral — permission / device / capture failure. */
+.avatar-glass-bar__live-dot--error {
+  background: #f0a4a4;
+  box-shadow:
+    0 0 5px rgba(240, 164, 164, 0.6),
+    0 0 10px rgba(240, 164, 164, 0.3);
+  animation: avatar-live-dot-breathe 2.8s ease-in-out infinite;
+}
+
+@keyframes avatar-live-dot-breathe {
   0%,
   100% {
     transform: scale(1);
-    opacity: 1;
-    box-shadow:
-      0 0 6px rgba(132, 204, 22, 0.85),
-      0 0 12px rgba(163, 230, 53, 0.55);
+    opacity: 0.85;
   }
   50% {
-    transform: scale(1.15);
-    opacity: 0.75;
-    box-shadow:
-      0 0 10px rgba(163, 230, 53, 1),
-      0 0 18px rgba(190, 242, 100, 0.65);
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .avatar-glass-bar__live-dot--waiting,
+  .avatar-glass-bar__live-dot--error,
+  .avatar-glass-bar__live-dot--live {
+    animation: none;
+    transform: none;
+    opacity: 1;
   }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Electron desktop companion first; browser localhost for development.
 | [VRMA animations](animations/vrma.md) | Default greeting + loop, individual clips |
 | [Manual animation testing](animations/manual-testing.md) | QA checklist for Default sequence |
 | [Audio sources](voice/audio-sources.md) | Desktop loopback, window, mic, file — full Voice panel reference |
-| [Lip sync](voice/lip-sync.md) | Amplitude visemes, live green dot, troubleshooting |
+| [Lip sync](voice/lip-sync.md) | Amplitude visemes, status-aware live dot, troubleshooting |
 | [VRoid Hub connection](vroid-hub.md) | Opt-in OAuth (Settings), pick characters in Appearance, session-only Hub VRMs |
 
 ## Project

--- a/docs/getting-started/first-session.md
+++ b/docs/getting-started/first-session.md
@@ -34,7 +34,7 @@ On first launch you get **Avatar 1**, **Default** animation (Greeting, then a lo
 ## 3. Try the essentials (2 minutes)
 
 1. Gear → **Appearance** → pick **Avatar 2** or **3**, then an environment (**Code**, **Stars**, **None**, …).  
-2. Gear → **Voice** → leave **Device output (auto)** (or pick a window / mic). Play music or a video — watch the mouth and the green dot.  
+2. Gear → **Voice** → leave **Device output (auto)** (or pick a window / mic). Play music or a video — watch the mouth and the live dot (mint when quiet, greener when loud).  
 3. Gear → **Animations** → try **Peace Sign**, then back to **Default**.  
 4. Gear → **Settings** → click a **3×3** cell to snap; drag the bar afterward and notice the pad deselects.  
 5. Scale menu → try **×0.5** then back to **×1**.  

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -71,7 +71,16 @@ Scale is remembered in `config.yaml`.
 
 ### Live lip-sync dot
 
-A **green pulsing dot** appears when lip sync is actively capturing (`Audio source` not Off, status **Capturing (local)**). Hover title: *Lip sync active*.
+When an audio source is selected (not **Off**), an 8px dot sits left of the gear:
+
+| Look | Meaning | Hover label |
+| :--- | :--- | :--- |
+| Soft **amber** | Waiting — source on, capture not ready yet | *Lip sync waiting for audio* |
+| Soft **mint** | Capturing, quiet | *Lip sync listening* |
+| Brighter **green** + stronger glow | Capturing, audio rising | *Lip sync active* |
+| Soft **coral** | Capture error (open **Voice**) | *Lip sync error — open Voice* |
+
+Loudness drives the green intensity while capturing; silence eases back to mint. With **reduced motion**, colors stay and the pulse freezes.
 
 ### Gear menu
 
@@ -388,7 +397,7 @@ Persistence details: [User settings](user-settings.md).
 1. Place the companion with drag or the snap pad.  
 2. Set scale ×0.5 / ×1 / ×2.  
 3. Appearance → pick avatar and environment. Optional: Settings → Directories for local folders, and/or Settings → connect VRoid Hub then Appearance → pick a Hub character.  
-4. Voice → Device output (or window/mic) until the green dot appears when sound plays.  
+4. Voice → Device output (or window/mic) until the live dot turns mint/green when sound plays.  
 5. Leave **Default** animation running, or pick a single clip.  
 6. Nudge Camera if framing feels off; use section resets or **Reset all** if you want a clean slate.
 

--- a/docs/voice/audio-sources.md
+++ b/docs/voice/audio-sources.md
@@ -55,7 +55,7 @@ System-wide **device output** loopback is an Electron feature — use the [Windo
 
 ## Live indicator
 
-When the source is not Off and status is **Capturing (local)** (internal `active`), a **green pulsing dot** appears on the glass bar (title: *Lip sync active*).
+When the source is not **Off**, a status-aware **live dot** sits on the glass bar (waiting amber → mint/green while capturing → coral on error). Green intensity tracks loudness; see [Lip sync → Live UI](lip-sync.md#live-ui).
 
 <p align="center">
   <img src="../screenshots/11-bar-live-dot.png" alt="Live lip-sync dot" height="120" />

--- a/docs/voice/lip-sync.md
+++ b/docs/voice/lip-sync.md
@@ -21,7 +21,15 @@ Pick the input first: [Audio sources](audio-sources.md). Everyday steps: [Using 
 
 ## Live UI
 
-Glass bar **green pulsing dot** = capture active and lip sync enabled.  
+Glass-bar **live dot** (left of the gear) reflects capture status and loudness — not a binary “on” light:
+
+| Dot | Meaning |
+| :--- | :--- |
+| Hidden | Audio source **Off** |
+| Soft amber | Source selected; waiting / starting |
+| Soft mint → brighter green | Capturing; green tracks analyser level |
+| Soft coral | Capture error — check Gear → **Voice** |
+
 Voice drawer shows a **plain-language status** (for example **Capturing (local)** or **Starting capture…**), a short **local-only privacy** note, and **Restart audio capture**. Permission failures include actionable copy (desktop can open system privacy settings). Details: [Audio sources → Privacy](audio-sources.md#privacy-what-stays-local).
 
 <p align="center">
@@ -32,5 +40,5 @@ Voice drawer shows a **plain-language status** (for example **Capturing (local)*
 ## Tips
 
 - Prefer **Device output** on desktop when watching videos or chatting with an AI that plays audio through the system.  
-- If the mouth never moves, confirm the green dot, OS mute, and that the selected window (if any) is actually producing sound.  
+- If the mouth never moves, confirm the live dot is mint/green (not amber waiting or coral error), OS mute, and that the selected window (if any) is actually producing sound.  
 - Extremely quiet sources may need higher OS volume or a closer mic.


### PR DESCRIPTION
Replace the binary green pulse with waiting (amber), live quiet-to-loud (mint to green via level ref), and error (coral). Update Voice/lip-sync docs and changelog for #42.

Closes #42